### PR TITLE
Docker Section

### DIFF
--- a/src/app/components/clt-editor/clt-editor.component.ts
+++ b/src/app/components/clt-editor/clt-editor.component.ts
@@ -10,7 +10,7 @@ require("./clt-editor.component.scss");
     selector: "ct-clt-editor",
     template: `
             <form class="clt-editor-group" [formGroup]="formGroup">
-                <docker-image-form [dockerRequirement]="model.hints?.DockerRequirement"
+                <docker-image-form [dockerRequirement]="model.hints.DockerRequirement"
                                    [form]="formGroup.controls['dockerGroup']"
                                    (update)="setRequirement($event, true)">
                 </docker-image-form>
@@ -29,7 +29,7 @@ require("./clt-editor.component.scss");
                 
                 <ct-argument-list [entries]="model.arguments || []" [readonly]="readonly"></ct-argument-list>
                 
-                <ct-file-def-list [entries]="model.requirements?.CreateFileRequirement?.fileDef || []"></ct-file-def-list>
+                <ct-file-def-list [entries]="model.requirements.CreateFileRequirement?.fileDef || []"></ct-file-def-list>
             </form>
 
             <sidebar-component></sidebar-component>

--- a/src/app/components/clt-editor/clt-editor.component.ts
+++ b/src/app/components/clt-editor/clt-editor.component.ts
@@ -2,7 +2,7 @@ import {Component, Input, OnInit} from "@angular/core";
 import {FormBuilder, FormGroup} from "@angular/forms";
 import {CommandLineToolModel, ExpressionModel} from "cwlts/models/d2sb";
 import {ComponentBase} from "../common/component-base";
-import {FileDef} from "cwlts/mappings/d2sb/FileDef";
+import {ProcessRequirement} from "cwlts/mappings/v1.0";
 
 require("./clt-editor.component.scss");
 
@@ -10,10 +10,9 @@ require("./clt-editor.component.scss");
     selector: "ct-clt-editor",
     template: `
             <form class="clt-editor-group" [formGroup]="formGroup">
-                <docker-image-form class="input-form" 
-                                [group]="formGroup"
-                                [cltModel]="model"
-                                [dockerPull]="'some.docker.image.com'">
+                <docker-image-form [dockerRequirement]="model.hints?.DockerRequirement"
+                                   [form]="formGroup.controls['dockerGroup']"
+                                   (update)="setRequirement($event, true)">
                 </docker-image-form>
                                 
                 <base-command-form [baseCommand]="model.baseCommand"
@@ -26,11 +25,11 @@ require("./clt-editor.component.scss");
                 
                 <ct-output-ports [entries]="model.outputs || []" [readonly]="readonly"></ct-output-ports>
                 
-                <ct-hint-list [entries]="model.hints || []" [readonly]="readonly"></ct-hint-list>
+                <ct-hint-list [entries]="model.hints || {}" [readonly]="readonly"></ct-hint-list>
                 
                 <ct-argument-list [entries]="model.arguments || []" [readonly]="readonly"></ct-argument-list>
                 
-                <ct-file-def-list [entries]="fileDefs || []"></ct-file-def-list>
+                <ct-file-def-list [entries]="model.requirements?.CreateFileRequirement?.fileDef || []"></ct-file-def-list>
             </form>
 
             <sidebar-component></sidebar-component>
@@ -48,22 +47,18 @@ export class CltEditorComponent extends ComponentBase implements OnInit {
     @Input()
     public formGroup: FormGroup;
 
-    private fileDefs: FileDef[] = [];
-
     constructor(private formBuilder: FormBuilder) {
         super();
     }
 
     ngOnInit() {
-        console.log("Model", this.model);
-        this.formGroup.addControl("dockerInputGroup", this.formBuilder.group({}));
+        this.formGroup.addControl("dockerGroup", this.formBuilder.group({}));
         this.formGroup.addControl("baseCommandGroup", this.formBuilder.group({}));
         this.formGroup.addControl("inputPortsGroup", this.formBuilder.group({}));
+    }
 
-        this.fileDefs = this.model.customProps.requirements
-            .filter(req => req.class === "CreateFileRequirement")
-            .map(req => req.fileDef)
-            .reduce((acc, item) => acc.concat(item) , []);
+    private setRequirement(req: ProcessRequirement, hint: boolean) {
+        this.model.setRequirement(req, hint);
     }
 
     private setBaseCommand(list: ExpressionModel[]) {

--- a/src/app/components/clt-editor/commandline/commandline.component.ts
+++ b/src/app/components/clt-editor/commandline/commandline.component.ts
@@ -37,7 +37,9 @@ export class CommandLineComponent {
         return {
             "arg-cli": part.type === "argument",
             "baseCmd-cli": part.type === "baseCommand",
-            "input-cli": part.type === "input"
+            "input-cli": part.type === "input",
+            "error-text": part.type === "error",
+            "warning-text": part.type === "warning"
         }
     }
 

--- a/src/app/components/clt-editor/hints/hint-list.component.ts
+++ b/src/app/components/clt-editor/hints/hint-list.component.ts
@@ -1,6 +1,7 @@
 import {Component, Input, ChangeDetectionStrategy} from "@angular/core";
 import {ComponentBase} from "../../common/component-base";
 import {ExternalLinks} from "../../../cwl/external-links";
+import {ExpressionModel} from "cwlts/models/d2sb";
 
 @Component({
     selector: "ct-hint-list",
@@ -13,14 +14,14 @@ import {ExternalLinks} from "../../../cwl/external-links";
 
             <div class="tc-body">
 
-                <ct-blank-tool-state *ngIf="!readonly && !entries.length"
+                <ct-blank-tool-state *ngIf="!readonly && !hints.length"
                                      [title]="'Special flags for tool execution'"
                                      [buttonText]="'Add a Hint'"
                                      [learnMoreURL]="helpLink"
                                      (buttonClick)="addEntry()">
                 </ct-blank-tool-state>
 
-                <div *ngIf="entries.length" class="container">
+                <div *ngIf="hints.length" class="container">
                     <div class="gui-section-list-title row">
                         <div class="col-sm-5">Class</div>
                         <div class="col-sm-7">Value</div>
@@ -28,12 +29,12 @@ import {ExternalLinks} from "../../../cwl/external-links";
 
                     <ul class="gui-section-list row">
 
-                        <li *ngFor="let entry of entries; let i = index"
+                        <li *ngFor="let entry of hints; let i = index"
                             class="gui-section-list-item clickable">
 
                             <div class="col-sm-5 ellipsis">{{ entry?.class }}</div>
 
-                            <div class="ellipsis col-sm-6" [class.col-sm-7]="readonly">{{ entry?.value }}</div>
+                            <div class="ellipsis col-sm-6" [class.col-sm-7]="readonly">{{ entry?.value?.toString() }}</div>
 
                             <div *ngIf="!readonly" class="col-sm-1 align-right">
                                 <i title="Delete" class="fa fa-trash text-hover-danger" (click)="removeEntry(i)"></i>
@@ -43,7 +44,7 @@ import {ExternalLinks} from "../../../cwl/external-links";
                     </ul>
                 </div>
 
-                <button *ngIf="!readonly && entries.length"
+                <button *ngIf="!readonly && hints.length"
                         (click)="addEntry()"
                         type="button"
                         class="btn pl-0 btn-link no-outline no-underline-hover">
@@ -57,7 +58,9 @@ export class HintListComponent extends ComponentBase {
 
     /** List of entries that should be shown */
     @Input()
-    public entries: {"class"?: string, value?: string}[] = [];
+    public entries: {[id:string]: {"class"?: string, value?: string}};
+
+    private hints: {"class"?: string, value?: string|ExpressionModel}[] = [];
 
     @Input()
     public readonly = false;
@@ -65,10 +68,14 @@ export class HintListComponent extends ComponentBase {
     private helpLink = ExternalLinks.hints;
 
     private addEntry() {
-        this.entries = this.entries.concat({});
+        this.hints = this.hints.concat({});
+    }
+
+    ngOnInit(): void {
+        this.hints = Object.keys(this.entries).map(key => this.entries[key]);
     }
 
     private removeEntry(index) {
-        this.entries = this.entries.slice(0, index).concat(this.entries.slice(index + 1));
+        this.hints = this.hints.slice(0, index).concat(this.hints.slice(index + 1));
     }
 }

--- a/src/app/components/forms/inputs/forms/base-command-form.component.ts
+++ b/src/app/components/forms/inputs/forms/base-command-form.component.ts
@@ -10,7 +10,7 @@ require("./base-command-form.components.scss");
 
 @Component({
     selector: 'base-command-form',
-    template: `<ct-form-section>
+    template: `<ct-form-panel>
     <div class="tc-header">
         Base Command
     </div>
@@ -42,7 +42,7 @@ require("./base-command-form.components.scss");
             </button>
         </form>
     </div>
-</ct-form-section>
+</ct-form-panel>
 
     `
 })
@@ -77,18 +77,18 @@ export class BaseCommandFormComponent extends ComponentBase implements OnInit, O
             };
         });
 
-        this.createExpressionInputControls(this.formList);
+        this.formList.forEach((item) => {
+            this.form.addControl(
+                item.id,
+                new FormControl(item.model, [Validators.required])
+            );
+        });
+
 
         this.tracked = this.form.valueChanges.subscribe(change => {
             const v = Object.keys(change).map(key => change[key]);
             this.update.next(v);
         })
-    }
-
-    private createExpressionInputControls(formList: Array<{id: string, model: ExpressionModel}>): void {
-        formList.forEach((item) => {
-            this.form.addControl(item.id, new FormControl(item.model, [Validators.required, CustomValidators.cwlModel]));
-        });
     }
 
     private removeBaseCommand(ctrl: {id: string, model: ExpressionModel}): void {
@@ -107,5 +107,10 @@ export class BaseCommandFormComponent extends ComponentBase implements OnInit, O
         this.formList.push(newCmd);
 
         this.form.markAsTouched();
+    }
+
+    ngOnDestroy() {
+        super.ngOnDestroy();
+        this.formList.forEach(item => this.form.removeControl(item.id));
     }
 }

--- a/src/app/components/forms/inputs/forms/docker-image-form.component.ts
+++ b/src/app/components/forms/inputs/forms/docker-image-form.component.ts
@@ -1,13 +1,15 @@
-import {Component, Input} from "@angular/core";
-import {Validators, FormBuilder, FormGroup} from "@angular/forms";
-import {CommandLineToolModel} from "cwlts/models/d2sb";
-import {FormSectionComponent} from "../../../form-section/form-section.component";
-import {AfterViewInit} from "../../../../../../node_modules/@angular/core/src/metadata/lifecycle_hooks";
+import {Component, Input, OnInit, Output} from "@angular/core";
+import {FormGroup, FormControl} from "@angular/forms";
+import {DockerRequirementModel} from "cwlts/models/d2sb";
+import {FormPanelComponent} from "../../../../core/elements/form-panel.component";
+import {ReplaySubject} from "rxjs";
+import {ComponentBase} from "../../../common/component-base";
+import {DockerRequirement} from "cwlts/mappings/d2sb/DockerRequirement";
 
 @Component({
     selector: 'docker-image-form',
     directives: [
-        FormSectionComponent
+        FormPanelComponent
     ],
     template: `
         <ct-form-section>
@@ -16,43 +18,46 @@ import {AfterViewInit} from "../../../../../../node_modules/@angular/core/src/me
             </div>
         
             <div class="tc-body">
-                <form [formGroup]="dockerInputForm">
+                <form [formGroup]="form" *ngIf="form">
         
                     <label for="docker_image" class="form-control-label">Docker Repository</label>
                     <input name="dockerPull"
                            type="text"
                            class="form-control"
                            id="docker_image"
-                           [formControl]="dockerInputForm.controls['dockerInput']"
-                           [(ngModel)]="dockerPull">
+                           [formControl]="form.controls['dockerPull']">
                 </form>
             </div>
         </ct-form-section>
-            
     `
 })
-export class DockerImageFormComponent implements AfterViewInit {
+export class DockerImageFormComponent extends ComponentBase implements OnInit {
     @Input()
-    public dockerPull: string;
-
-    @Input()
-    public cltModel: CommandLineToolModel;
+    public dockerRequirement: DockerRequirementModel;
 
     /** The parent forms control group */
     @Input()
-    public group: FormGroup;
+    public form: FormGroup;
 
-    private dockerInputForm: FormGroup;
+    @Output()
+    public update = new ReplaySubject<DockerRequirement>();
 
-    constructor(private formBuilder: FormBuilder) {
-        this.dockerInputForm = this.formBuilder.group({
-            dockerInput: ['', Validators.compose([Validators.required, Validators.minLength(1)])]
+    ngOnInit(): void {
+        const dockerPull = this.dockerRequirement ? this.dockerRequirement.dockerPull : "";
+        this.form.addControl("dockerPull", new FormControl(dockerPull));
+
+        this.tracked = this.form.valueChanges.subscribe(changes => {
+            const docker: DockerRequirement = this.dockerRequirement ?
+                this.dockerRequirement.serialize() :
+                <DockerRequirement>{};
+
+            docker.dockerPull = changes["dockerPull"];
+            this.update.next(docker);
         });
-
     }
 
-    ngAfterViewInit(): void {
-        // this.group.addControl('dockerInput', this.dockerInputForm.controls['dockerInput']);
-
+    ngOnDestroy() {
+        super.ngOnDestroy();
+        this.form.removeControl("dockerPull");
     }
 }

--- a/src/app/components/forms/inputs/forms/docker-image-form.component.ts
+++ b/src/app/components/forms/inputs/forms/docker-image-form.component.ts
@@ -49,7 +49,7 @@ export class DockerImageFormComponent extends ComponentBase implements OnInit {
         this.tracked = this.form.valueChanges.subscribe(changes => {
             const docker: DockerRequirement = this.dockerRequirement ?
                 this.dockerRequirement.serialize() :
-                <DockerRequirement>{};
+                new DockerRequirementModel();
 
             docker.dockerPull = changes["dockerPull"];
             this.update.next(docker);

--- a/src/app/components/forms/inputs/types/input-port-list.component.ts
+++ b/src/app/components/forms/inputs/types/input-port-list.component.ts
@@ -20,8 +20,8 @@ import {CommandInputParameterModel as InputProperty} from "cwlts/models/d2sb";
                     [class.error]="input.validation.errors.length"
                     [class.warning]="input.validation.warnings.length"
                     [class.selected]="i === selectedIndex"
-                    *ngFor="let input of portList; let i = index">
-                    <!-- @todo: temporarily removing edit method -->
+                    *ngFor="let input of portList; let i = index"
+                    (click)="editProperty(i)">
         
                     <div class="col-sm-4 ellipsis" [title]="input.id">
                         <i class="fa fa-warning validation-icon"

--- a/src/app/components/tool-editor/tool-editor.component.scss
+++ b/src/app/components/tool-editor/tool-editor.component.scss
@@ -123,9 +123,6 @@ ct-code-editor {
     &:hover {
         background: $gui-section-list-item-hover-bg;
         color: $gui-section-list-item-hover-color;
-        .fa {
-            color: $gui-section-list-item-hover-icon-color;
-        }
     }
 
     &.selected {

--- a/src/app/components/tool-editor/tool-editor.component.scss
+++ b/src/app/components/tool-editor/tool-editor.component.scss
@@ -92,14 +92,6 @@ ct-code-editor {
         .error {
             color: $brand-danger;
         }
-
-        .error-text {
-            color: lighten($brand-danger, 30%);
-        }
-
-        .warning-text {
-            color: $brand-warning;
-        }
     }
 }
 
@@ -165,6 +157,15 @@ ct-code-editor {
 
     .console-content {
         padding: 14px;
+
+
+        .error-text {
+            color: $console-error-color;
+        }
+
+        .warning-text {
+            color: $console-warning-color;
+        }
     }
 
     &.show {

--- a/src/app/components/tree-view/tree-node.component.ts
+++ b/src/app/components/tree-view/tree-node.component.ts
@@ -17,6 +17,7 @@ import {ComponentBase} from "../common/component-base";
 
 @Component({
     selector: "ct-tree-node",
+    changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <div #nodeBase
              class="deep-unselectable clickable node-base"

--- a/src/app/cwl/pipes/command-parameter-type.pipe.ts
+++ b/src/app/cwl/pipes/command-parameter-type.pipe.ts
@@ -6,14 +6,13 @@ export class CommandParameterTypePipe implements PipeTransform {
     transform(type): any {
 
         try {
-            const resolved = TypeResolver.resolveType(type);
-            let output     = resolved.type;
+            let output     = type.type;
 
-            if (resolved.type === "array") {
-                output = `Array<${resolved.items}>`;
+            if (type.type === "array") {
+                output = `Array<${type.items}>`;
             }
 
-            return output + (resolved.isRequired ? "" : "?");
+            return output + (type.isNullable ? "?" : "");
         } catch (ex) {
             return "n/a";
         }

--- a/src/app/tool-editor/sections/arguments/argument-list.component.scss
+++ b/src/app/tool-editor/sections/arguments/argument-list.component.scss
@@ -1,0 +1,8 @@
+@import "../../../../assets/sass/variables";
+@import "../../../../assets/sass/mixins";
+
+ct-argument-list .form-section {
+  @include cli-border($arg-color);
+}
+
+

--- a/src/app/tool-editor/sections/arguments/argument-list.component.ts
+++ b/src/app/tool-editor/sections/arguments/argument-list.component.ts
@@ -2,6 +2,8 @@ import {Component, Input, ChangeDetectionStrategy, OnChanges, SimpleChanges} fro
 import {ComponentBase} from "../../../components/common/component-base";
 import {CommandArgumentModel} from "cwlts/models/d2sb";
 
+require("./argument-list.component.scss");
+
 @Component({
     selector: "ct-argument-list",
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/assets/sass/_theme-variables.scss
+++ b/src/assets/sass/_theme-variables.scss
@@ -54,6 +54,8 @@ $base-cmd-color: #7AC24D;
 $input-port-color: #A77ED7;
 $output-port-color: $uncoded-color;
 $arg-color: #FDA365;
+$console-error-color: lighten($brand-danger, 30%);
+$console-warning-color: $brand-warning;
 
 
 /**
@@ -121,8 +123,8 @@ $expression-editor-help-icon-color: #818286;
 $expression-editor-border: #3B3F46;
 
 $expression-editor-text-muted: #555658;
-$expression-editor-error-color: lighten($brand-danger, 30%);
-$expression-editor-warning-color: #fdb855;
+$expression-editor-error-color: $console-error-color;
+$expression-editor-warning-color: $console-warning-color;
 
 $expression-editor-result-height: 150px;
 


### PR DESCRIPTION
Connected Docker section with model. Editing input field in Docker section will trigger changes in the model and serialize the tool.

![rabix-editor](https://cloud.githubusercontent.com/assets/6614995/20632816/79d156aa-b340-11e6-8b12-7d58512c9aec.png)

While working on this feature, I came across a place for potential bugs. Because the `ToolEditorComponent` is supplying the root form for the `CltEditorComponent` and all its children, new formControls are only created the first time GUI mode is activated. Every subsequent time, nothing will happen because formControls with those names already exist. It should be a best practice to remove formControls that a component created on an @Input form when it's being destroyed. Basically:

```typescript
@Input()
public form: FormGroup;

ngOnInit(): void {
    this.form.addControl("dockerPull", new FormControl(dockerPull));
}

ngOnDestroy() {
    this.form.removeControl("dockerPull");
}
```

**tl;dr: Docker section and cleanup formControls components create.**